### PR TITLE
UI class use private members and update CAN DB

### DIFF
--- a/Common/include/candb.hpp
+++ b/Common/include/candb.hpp
@@ -6,12 +6,12 @@
  *
  */
 struct UserInputCanFrame {
-  unsigned frame_counter : 4;
-  unsigned ignition : 2;
-  unsigned gear_select : 4;
-  unsigned throttle : 8;
-  unsigned brake : 8;
-  unsigned blinkers : 2;
+  unsigned frame_counter : 4;   //!< Incremental frame counter, 4 bit.
+  unsigned ignition : 2;        //!< Ignition state, 2 bit.
+  unsigned gear_select : 4;     //!< Gear selection PRND, 4 bit.
+  unsigned throttle : 8;        //!< Throttle request, 8 bit.
+  unsigned brake : 8;           //!< Brake request, 8 bit.
+  unsigned turn_indicator : 2;  //!< Turn indicator incl. warning, 2 bit.
 };
 
 /*!
@@ -19,12 +19,22 @@ struct UserInputCanFrame {
  *
  */
 struct DisplayCanFrame {
-  unsigned frame_counter : 4;
-  unsigned ignition : 2;
-  unsigned gear_select : 4;
-  unsigned speed : 8;
-  unsigned rpm : 8;
-  unsigned blinkers : 2;
+  unsigned frame_counter : 4;   //!< Incremental frame counter, 4 bit.
+  unsigned ignition : 2;        //!< Ignition state, 2 bit.
+  unsigned gear_select : 4;     //!< Gear selection PRND, 4 bit.
+  unsigned speed : 8;           //!< Vehicle speed, 8 bit.
+  unsigned rpm : 8;             //!< Engine RPM, 8 bit.
+  unsigned turn_indicator : 2;  //!< Turn indicator incl. warning, 2 bit.
+  unsigned automatic_gear : 3;  //!< Current gear engaged, 3 bit.
+};
+
+/*!
+ * \brief Enum representation of CAN frame IDs.
+ *
+ */
+enum class CanFrameId {
+  kUserInputCanFrameId = 0,
+  kDisplayCanFrameId,
 };
 
 /*!
@@ -68,10 +78,10 @@ enum class Pedal {
 };
 
 /*!
- * \brief Enum representation of blinker state.
+ * \brief Enum representation of turn indicator state.
  *
  */
-enum class Blinker {
+enum class TurnIndicator {
   kOff = 0,
   kRight,
   kLeft,

--- a/Common/include/socketcan.hpp
+++ b/Common/include/socketcan.hpp
@@ -45,4 +45,5 @@ class SocketCan {
   std::string m_interface;
   SocketMode m_socket_mode;
 };
+
 }  // namespace scpp

--- a/Common/src/socketcan.cpp
+++ b/Common/src/socketcan.cpp
@@ -8,8 +8,8 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <unistd.h>
-/* CAN DLC to real data length conversion helpers */
 
+/* CAN DLC to real data length conversion helpers */
 static const unsigned char dlc2len[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64};
 
 /* get data length from can_dlc with sanitized can_dlc */
@@ -34,6 +34,7 @@ unsigned char can_len2dlc(unsigned char len) {
 }
 
 namespace scpp {
+
 SocketCan::SocketCan() {}
 SocketCanStatus SocketCan::open(const std::string &can_interface, int32_t read_timeout_ms, SocketMode mode) {
   m_interface = can_interface;
@@ -45,6 +46,7 @@ SocketCanStatus SocketCan::open(const std::string &can_interface, int32_t read_t
     perror("socket");
     return STATUS_SOCKET_CREATE_ERROR;
   }
+
   int mtu, enable_canfd = 1;
   struct sockaddr_can addr;
   struct ifreq ifr;
@@ -66,6 +68,7 @@ SocketCanStatus SocketCan::open(const std::string &can_interface, int32_t read_t
       perror("SIOCGIFMTU");
       return STATUS_MTU_ERROR;
     }
+
     mtu = ifr.ifr_mtu;
 
     if (mtu != CANFD_MTU) {
@@ -91,6 +94,7 @@ SocketCanStatus SocketCan::open(const std::string &can_interface, int32_t read_t
 
   return STATUS_OK;
 }
+
 SocketCanStatus SocketCan::write(const CanFrame &msg) {
   struct canfd_frame frame;
   memset(&frame, 0, sizeof(frame)); /* init CAN FD frame, e.g. LEN = 0 */
@@ -112,13 +116,13 @@ SocketCanStatus SocketCan::write(const CanFrame &msg) {
 
   return STATUS_OK;
 }
+
 SocketCanStatus SocketCan::read(CanFrame &msg) {
   struct canfd_frame frame;
 
   // Read in a CAN frame
   auto num_bytes = ::read(m_socket, &frame, CANFD_MTU);
   if (num_bytes != CAN_MTU && num_bytes != CANFD_MTU) {
-    // perror("Can read error");
     return STATUS_READ_ERROR;
   }
 
@@ -129,7 +133,9 @@ SocketCanStatus SocketCan::read(CanFrame &msg) {
 
   return STATUS_OK;
 }
+
 SocketCanStatus SocketCan::close() { return STATUS_OK; }
 const std::string &SocketCan::interfaceName() const { return m_interface; }
 SocketCan::~SocketCan() { close(); }
+
 }  // namespace scpp

--- a/Emulator/doc/SWDesign.plantuml
+++ b/Emulator/doc/SWDesign.plantuml
@@ -12,13 +12,13 @@ package "DriveLine" {
 }
 
 package "Display" {
-  [CANReciever]
+  [CANReceiver]
   [display]
 }
 
 [CANTransmitter] --> [CANTransiever] : vcan0
 [CANTransiever] <-> [Server]
-[CANTransiever] --> [CANReciever] : vcan0
-[CANReciever] --> [display]
+[CANTransiever] --> [CANReceiver] : vcan0
+[CANReceiver] --> [display]
 
 @enduml

--- a/UserInput/include/ui.hpp
+++ b/UserInput/include/ui.hpp
@@ -1,4 +1,6 @@
 #include <curses.h>
+
+#include <atomic>
 #include <mutex>
 
 #include "candb.hpp"
@@ -46,10 +48,7 @@ const int k_s = 115;
  */
 class UserInput {
  public:
-  UserInputCanFrame can_frame_bitfield{};
-
-  // Input char
-  int ch{};
+  int ch{};  //!< Input char value.
 
   bool Cmd();
   void UpdateCanFrameBitfield();
@@ -57,19 +56,24 @@ class UserInput {
   void SetGear(const Gear&);
   void SetThrottle(const Pedal&);
   void SetBrake(const Pedal&);
-  void SetBlinker(const Blinker&);
+  void SetTurnIndicator(const TurnIndicator&);
+  void StartCanSender();
+  void StopCanSender();
 
-  /*! \todo Make these private!  */
-  // Input request variables
+ private:
+  UserInputCanFrame can_frame_bitfield{};
   Ignition ignition{};
   Gear gear_selection{};
   Pedal throttle{};
   Pedal brake{};
-  Blinker blinker{};
+  TurnIndicator turn_indicator{};
+  std::atomic<bool> can_sender_run{};
+  std::mutex mx{};
+
+  void CanSend();
 };
 
 void InitNcurses();
-void SendToCan(const bool&, const UserInputCanFrame&, std::mutex&);
 
 }  // namespace ui
 

--- a/UserInput/src/main.cpp
+++ b/UserInput/src/main.cpp
@@ -10,24 +10,19 @@ int main() {
   // Initiate persistent variables.
   bool run{true};
   ui::UserInput ui{};
-  std::mutex mx{};
 
   ui::InitNcurses();
 
-  std::thread can_thread(ui::SendToCan, std::ref(run), std::ref(ui.can_frame_bitfield), std::ref(mx));
+  // std::thread can_thread(&ui.CanSend);
+  ui.StartCanSender();
 
   // Will loop until false is returned from input check.
   while (run) {
     if ((ui.ch = getch()) != ERR) {
       run = ui.Cmd();
-
-      // Lock mutex and update.
-      std::lock_guard<std::mutex> lk(mx);
       ui.UpdateCanFrameBitfield();
     }
   }
-
-  can_thread.join();
 
   return endwin();
 }

--- a/UserInput/src/main.cpp
+++ b/UserInput/src/main.cpp
@@ -24,5 +24,7 @@ int main() {
     }
   }
 
+  ui.StopCanSender();
+
   return endwin();
 }


### PR DESCRIPTION
- Renamed SendToCan() to CanSend().
- CanSend() now is private and takes no parameteres.
- UI class now uses private mutex.
- UI class no longer exposes all its input variables.
- Spelling correction in SW design diagram.
- Formatting on socketcan.cpp and .hpp.
- Update candb.hpp with comments and renamed blinker to turn indicator.